### PR TITLE
pin netbox container to 2.3.7 before major API changes

### DIFF
--- a/automation/roles/netbox/tasks/main.yaml
+++ b/automation/roles/netbox/tasks/main.yaml
@@ -17,6 +17,8 @@
 
 - name: Netbox docker compose
   shell: 'cd /home/cumulus/netbox-docker;docker-compose pull;docker-compose up -d'
+  environment:
+    VERSION: v2.3.7
   when:
     - netbox_state.stdout.find('netbox') == -1
 


### PR DESCRIPTION
Netbox 2.4 made significant API changes that will break the python scripts. This will pin the netbox to the last 2.3 container until we can fix the scripts and upgrade